### PR TITLE
fix: docstring on an empty function

### DIFF
--- a/NetworkCore/Behavior.py
+++ b/NetworkCore/Behavior.py
@@ -169,7 +169,7 @@ class Behavior(TaggableObjectBase):
             pass
 
         def empty_func_with_docstring():
-            #Empty function with docstring.
+            """Empty function with docstring."""
             pass
 
         def constants(f):


### PR DESCRIPTION
Comments, unlike docstrings, do not change `co_code`